### PR TITLE
Refactor app-drawer to use web-animations

### DIFF
--- a/app-widgets.html
+++ b/app-widgets.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <link rel="import" href="bower_components/polymer/polymer.html">
+<link rel="import" href="bower_components/polymer-animation/web-animations.html">
 <script src="dynamics.js"></script>
 <style>
 html {
@@ -93,9 +94,6 @@ body {
         var mask = this.$.mask;
         this.controller = new DrawerController({
             target: this,
-            left: 0,
-            right: 300,
-            position: 0,
             curve: 'ease-in-out',
             willOpen: function() {
                 mask.style.display = 'block';
@@ -107,11 +105,16 @@ body {
                 content.style.display = 'none';
                 this.active = false;
             },
-            onAnimate: function(position) {
-                // FIXME: We should animate the opacity from zero, but that triggers http://crbug.com/328106
-                mask.style.opacity = ((position + 1) / 300) * 0.2;
-                content.style.WebkitTransform = 'translate3d(' + (position - 300) + 'px,0,0)';
-            },
+            movement: 300,
+            animation: new ParGroup([
+              // FIXME: We should animate the opacity from zero, but that triggers http://crbug.com/328106
+              new Animation(mask, 
+                  [{opacity: 0.001}, {opacity: 0.2}],
+                  {duration: 1, fill: 'both'}),
+              new Animation(content,
+                  [{transform: 'translate3d(-300px, 0, 0)'}, {transform: 'translate3d(0px, 0, 0)'}],
+                  {duration: 1, fill: 'both'})
+            ], {fill: 'both'}),
         });
       },
     });


### PR DESCRIPTION
Quick summary of how this works:
* The opacity/transform animations are bundled into a group and then managed by the `DrawerController`.
* `DrawerController` wraps the composed animation in a group so that it can control direction and easing independently.
* The animation is set up to have a duration of '1' to simplify calculations.

The behavior of the drawer is then broken down into these operations:

`resumeAnimation(direction)`
* Begins opening/closing the drawer from its current position over 400ms with the specified easing.
* This is achieved by slicing the animation such that it starts at the current position and finishes at one end.
* The direction is specified on the container and the playback rate on the player is set appropriately for 400ms of animation.

`fling(velocity)`
* Starts a `resumeAnimation` in the appropriate direction.
* Sets linear easing and adjusts the playback rate to match the velocity.

`prepareForScrubbing()`
* Sets up a linear easing and pauses the player.

scrubbing is handled in `onTouchMove` by adjusting the player's `currentTime` relative to the delta.